### PR TITLE
Implementação da API de detalhe para livros

### DIFF
--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/autor/AutorDetalheDTO.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/autor/AutorDetalheDTO.java
@@ -1,0 +1,20 @@
+package br.com.zupacademy.ggwadera.casadocodigo.autor;
+
+public class AutorDetalheDTO {
+
+    private String nome;
+    private String descricao;
+
+    public AutorDetalheDTO(Autor autor) {
+        this.nome = autor.getNome();
+        this.descricao = autor.getDescricao();
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/livro/LivroController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/livro/LivroController.java
@@ -2,8 +2,10 @@ package br.com.zupacademy.ggwadera.casadocodigo.livro;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -31,5 +33,13 @@ public class LivroController {
     public ResponseEntity<Page<LivroItemListaDTO>> listar(Pageable pageable) {
         final Page<LivroItemListaDTO> livros = livroRepository.findAll(pageable).map(LivroItemListaDTO::new);
         return ResponseEntity.ok(livros);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LivroDetalheDTO> buscar(@PathVariable Long id) {
+        final Livro livro = livroRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                "Não foi encontrado um livro com o id " + id));
+        return ResponseEntity.ok(new LivroDetalheDTO(livro));
     }
 }

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/livro/LivroDetalheDTO.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/livro/LivroDetalheDTO.java
@@ -1,0 +1,67 @@
+package br.com.zupacademy.ggwadera.casadocodigo.livro;
+
+import br.com.zupacademy.ggwadera.casadocodigo.autor.AutorDetalheDTO;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class LivroDetalheDTO {
+
+    private final String titulo;
+    private final String resumo;
+    private final String sumario;
+    private final BigDecimal preco;
+    private final Integer numeroDePaginas;
+    private final String isbn;
+    private final String categoria;
+    private final LocalDate dataPublicacao;
+    private final AutorDetalheDTO autor;
+
+    public LivroDetalheDTO(Livro livro) {
+        this.titulo = livro.getTitulo();
+        this.resumo = livro.getResumo();
+        this.sumario = livro.getSumario();
+        this.preco = livro.getPreco();
+        this.numeroDePaginas = livro.getNumeroDePaginas();
+        this.isbn = livro.getIsbn();
+        this.categoria = livro.getCategoria().getNome();
+        this.dataPublicacao = livro.getDataPublicacao();
+        this.autor = new AutorDetalheDTO(livro.getAutor());
+    }
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public String getResumo() {
+        return resumo;
+    }
+
+    public String getSumario() {
+        return sumario;
+    }
+
+    public BigDecimal getPreco() {
+        return preco;
+    }
+
+    public Integer getNumeroDePaginas() {
+        return numeroDePaginas;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public String getCategoria() {
+        return categoria;
+    }
+
+    public LocalDate getDataPublicacao() {
+        return dataPublicacao;
+    }
+
+    public AutorDetalheDTO getAutor() {
+        return autor;
+    }
+}


### PR DESCRIPTION
Precisamos criar uma página com as mesmas informações que encontramos na página de detalhe da Casa do Código. Aqui está a página real => [https://www.casadocodigo.com.br/products/livro-spring-boot](https://www.casadocodigo.com.br/products/livro-spring-boot)

**A ideia aqui é implementar todo código necessário para que tenhamos uma página com quase todas informações da página de detalhe da CDC.**

### **Necessidades**

*   Ter um endpoint que em função de um id de livro retorne os detalhes necessários para montar a página.

### **Restrições**

*   Se o id não existir é para retornar 404

### **Resultado esperado**

*   que o front possa montar a página