### PR TITLE
Cadastro de país e estado

### DIFF
--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/Estado.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/Estado.java
@@ -1,0 +1,43 @@
+package br.com.zupacademy.ggwadera.casadocodigo.estado;
+
+import br.com.zupacademy.ggwadera.casadocodigo.pais.Pais;
+
+import javax.persistence.*;
+
+@Entity
+@Table(
+    uniqueConstraints = @UniqueConstraint(columnNames = {"pais_id", "nome"})
+)
+public class Estado {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nome;
+
+    @ManyToOne(optional = false)
+    private Pais pais;
+
+    @Deprecated
+    public Estado() {
+    }
+
+    public Estado(String nome, Pais pais) {
+        this.nome = nome;
+        this.pais = pais;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public Pais getPais() {
+        return pais;
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/EstadoController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/EstadoController.java
@@ -1,0 +1,29 @@
+package br.com.zupacademy.ggwadera.casadocodigo.estado;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/estados")
+public class EstadoController {
+
+    @PersistenceContext
+    private EntityManager manager;
+
+    @PostMapping
+    @Transactional
+    public ResponseEntity<Void> cadastrar(@RequestBody @Valid EstadoNovoDTO dto) {
+        final Estado estado = dto.toModel(manager);
+        manager.persist(estado);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/EstadoNovoDTO.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/estado/EstadoNovoDTO.java
@@ -1,0 +1,33 @@
+package br.com.zupacademy.ggwadera.casadocodigo.estado;
+
+import br.com.zupacademy.ggwadera.casadocodigo.pais.Pais;
+import br.com.zupacademy.ggwadera.casadocodigo.util.annotations.ExistsId;
+import br.com.zupacademy.ggwadera.casadocodigo.util.annotations.UniqueStateName;
+
+import javax.persistence.EntityManager;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@UniqueStateName
+public class EstadoNovoDTO {
+
+    @NotBlank
+    private String nome;
+
+    @NotNull
+    @ExistsId(domainClass = Pais.class)
+    private Long paisId;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public Long getPaisId() {
+        return paisId;
+    }
+
+    public Estado toModel(EntityManager manager) {
+        final Pais pais = manager.find(Pais.class, paisId);
+        return new Estado(nome, pais);
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/NovoPaisDTO.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/NovoPaisDTO.java
@@ -1,0 +1,24 @@
+package br.com.zupacademy.ggwadera.casadocodigo.pais;
+
+import br.com.zupacademy.ggwadera.casadocodigo.util.annotations.UniqueValue;
+
+import javax.validation.constraints.NotBlank;
+
+public class NovoPaisDTO {
+
+    @NotBlank
+    @UniqueValue(domainClass = Pais.class, fieldName = "nome")
+    private String nome;
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public Pais toModel() {
+        return new Pais(this.nome);
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/Pais.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/Pais.java
@@ -1,0 +1,35 @@
+package br.com.zupacademy.ggwadera.casadocodigo.pais;
+
+import org.hibernate.annotations.NaturalId;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Pais {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NaturalId
+    private String nome;
+
+    @Deprecated
+    public Pais() {
+    }
+
+    public Pais(String nome) {
+        this.nome = nome;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/PaisController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/pais/PaisController.java
@@ -1,0 +1,29 @@
+package br.com.zupacademy.ggwadera.casadocodigo.pais;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/paises")
+public class PaisController {
+
+    @PersistenceContext
+    private EntityManager manager;
+
+    @PostMapping
+    @Transactional
+    public ResponseEntity<Void> cadastrar(@RequestBody @Valid NovoPaisDTO dto) {
+        final Pais pais = dto.toModel();
+        manager.persist(pais);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/util/annotations/UniqueStateName.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/util/annotations/UniqueStateName.java
@@ -1,0 +1,19 @@
+package br.com.zupacademy.ggwadera.casadocodigo.util.annotations;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Constraint(validatedBy = {UniqueStateNameValidator.class})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueStateName {
+
+    String message() default "já existe um estado com esse nome no país selecionado";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/util/annotations/UniqueStateNameValidator.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/casadocodigo/util/annotations/UniqueStateNameValidator.java
@@ -1,0 +1,38 @@
+package br.com.zupacademy.ggwadera.casadocodigo.util.annotations;
+
+import br.com.zupacademy.ggwadera.casadocodigo.estado.Estado;
+import br.com.zupacademy.ggwadera.casadocodigo.estado.EstadoNovoDTO;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class UniqueStateNameValidator implements ConstraintValidator<UniqueStateName, EstadoNovoDTO> {
+
+    @PersistenceContext
+    private EntityManager manager;
+
+    @Override
+    public void initialize(UniqueStateName constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(EstadoNovoDTO estado, ConstraintValidatorContext context) {
+        if (estado == null) return true;
+        final List<?> resultList = manager
+            .createQuery("select 1 from " + Estado.class.getName() + " where nome = :nome and pais_id = :pais_id")
+            .setParameter("nome", estado.getNome())
+            .setParameter("pais_id", estado.getPaisId())
+            .getResultList();
+        final boolean isValid = resultList.isEmpty();
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context
+                .buildConstraintViolationWithTemplate("já existe um estado com esse nome no país selecionado")
+                .addPropertyNode("nome").addConstraintViolation();
+        }
+        return isValid;
+    }
+}


### PR DESCRIPTION
### **Necessidades**

Precisamos de um cadastro simples de países e seus respectivos estados.

Cada país tem um nome e cada estado tem um nome e pertence a um país.

### **Restrições para país**

*   o nome é obrigatório
*   o nome é único

### **Restrição para estados**

*   o nome é obrigatório
*   o nome é único para o mesmo país
*   o país é obrigatório

### **Resultado esperado**

*   Dois endpoints para que seja possível cadastrar países e estados. Pode existir país sem estados associados.
*   Caso alguma restrição não seja atendida, retornar 400 e json com os problemas de validação.